### PR TITLE
update `network_builder`

### DIFF
--- a/bin/network_builder.R
+++ b/bin/network_builder.R
@@ -217,7 +217,7 @@ cat(".. number of constrained axes: ", length(cap$CCA$eig), "\n")
 ## Extract scores
 capscores <- data.frame(
   GeneID = rownames(cap$CCA$v),
-  scores(cap, display = "species", choices = seq(1, length(final_meta_columns))))
+  scores(cap, display = "species", choices = 1:length(cap$CCA$eig)))
 
 ## Add CAP scores as node attributes
 node_labs <- V(g)$name

--- a/bin/network_builder.R
+++ b/bin/network_builder.R
@@ -220,6 +220,7 @@ capscores <- data.frame(
   scores(cap, display = "species", choices = 1:length(cap$CCA$eig)))
 
 ## Add CAP scores as node attributes
+cat("Adding db-RDA scores to graph\n")
 node_labs <- V(g)$name
 for(i in seq(1, length(cap$CCA$eig))){
     capCol = paste("CAP", i, sep = "")
@@ -245,7 +246,7 @@ for(i in seq(1, length(cap$CCA$eig))){
 
 }
 
-
 # Writes Graph
+cat("\nExporting graph\n")
 write_graph(g,  gsub(".csv", ".graphml", input_file), "graphml")
 

--- a/bin/network_builder.R
+++ b/bin/network_builder.R
@@ -72,12 +72,21 @@ df_meta <- as.data.frame(df_meta)
 
 rownames(df_meta) <- df_meta$SampleID
 
-# Removes NA Columns
+## Handle missing data in metadata
+nacolz <- colSums(is.na(df_meta)) != 0
+if(any(nacolz)){
+    cat("\nWARNING: There are ", sum(nacolz), "columns with missing data:\n")
+    cat("  ", paste(colnames(df_meta)[ nacolz ], collapse = ", "), "\n")
+
 if(replace_missing == FALSE){
-    df_meta <- df_meta[, colSums(is.na(df_meta)) == 0]
+        ## Removes NA Columns
+        cat(".. These columns will be removed\n")
+        df_meta <- df_meta[, ! nacolz ]
 } else {
     ## Replace missing values in metadata
+        # cat(".. Imputing missing values\n")
     # df_meta <- pca_impute(...)
+    }
 }
 
 # Metadata variables that will be used for ordination

--- a/bin/network_builder.R
+++ b/bin/network_builder.R
@@ -1,5 +1,13 @@
 #!/usr/bin/env Rscript
 
+## Usage
+# Rscript network_builder.R \
+#  --input_file gene_abundances_long.csv \
+#  --only_positive TRUE \
+#  --metadata_file sample_metadata.xlsx \
+#  --replace_missing FALSE \
+#  --metadata_cols "CN,H2O_content_volumetric,Annual_Precipitation,Annual_Mean_Temperature"
+
 
 load_pckg <- function(pkg = "data.table"){
     suppressPackageStartupMessages( library(package = pkg, character.only = TRUE) )

--- a/bin/network_builder.R
+++ b/bin/network_builder.R
@@ -61,7 +61,7 @@ if(selected_meta_columns %in% "NA"){ selected_meta_columns <- NA }
 if(is.na(selected_meta_columns)){
     selected_meta_columns <- colnames(df_meta)[ ! colnames(df_meta) %in% "SampleID" ]
 } else {
-    selected_meta_columns <- strsplit(c, split = ",")[[1]]
+    selected_meta_columns <- strsplit(selected_meta_columns, split = ",")[[1]]
 }
 
 # Subset metadata

--- a/bin/network_builder.R
+++ b/bin/network_builder.R
@@ -1,14 +1,19 @@
 #!/usr/bin/env Rscript
 
-# SPRING Testing
-library(SPRING)
-library(tidyr)
-library(dplyr)
-library(vegan)
-library(igraph)
-library(optparse)
-library(readxl)
-library(missMDA)
+
+load_pckg <- function(pkg = "data.table"){
+    suppressPackageStartupMessages( library(package = pkg, character.only = TRUE) )
+    cat(paste(pkg, packageVersion(pkg), "\n"))
+}
+
+load_pckg("SPRING")
+load_pckg("tidyr")
+load_pckg("dplyr")
+load_pckg("vegan")
+load_pckg("igraph")
+load_pckg("optparse")
+load_pckg("readxl")
+load_pckg("missMDA")
 
 
 seed <- 42

--- a/bin/network_builder.R
+++ b/bin/network_builder.R
@@ -221,18 +221,25 @@ capscores <- data.frame(
 
 ## Add CAP scores as node attributes
 node_labs <- V(g)$name
-for(i in seq(1, length(final_meta_columns)))
-{
+for(i in seq(1, length(cap$CCA$eig))){
     capCol = paste("CAP", i, sep = "")
+    
     # Adds value
-    g <- set_vertex_attr(g, capCol, index = node_labs, capscores[ match(x = node_labs, table = capscores$GeneID), capCol ])
+    g <- set_vertex_attr(
+        g,
+        capCol,
+        index = node_labs, capscores[ match(x = node_labs, table = capscores$GeneID), capCol ]
+        )
 
     # Adds Assortativity
-    g <- set_graph_attr(g, paste("assortativity",capCol, sep = "_"), igraph::assortativity(pos_g, values = vertex_attr(g, capCol, index = V(g))))
+    g <- set_graph_attr(
+        g,
+        paste("assortativity", capCol, sep = "_"),
+        igraph::assortativity(pos_g, values = vertex_attr(g, capCol, index = V(g)))
+        )
 
     # Add the biplot values for projection of the CAP values
-    for(col in final_meta_columns)
-    {
+    for(col in rownames(cap$CCA$biplot)){
         g <- set_graph_attr(g, paste(capCol, col, sep = "-"), cap$CCA$biplot[col, capCol])
     }
 

--- a/bin/network_builder.R
+++ b/bin/network_builder.R
@@ -101,9 +101,9 @@ df <- read.csv(input_file) %>%
 # Validate sample sets
 nonoverlaping_samples <- setdiff(unique(df$SampleID), unique(df_meta$SampleID))
 if(length(nonoverlaping_samples) > 0){
-    cat("\nWARNING: some samples are missing from metadata or gene-abundnace table:\n")
+    cat("\nWARNING: some samples are missing from metadata or gene-abundance table:\n")
     cat("  n = ", length(nonoverlaping_samples), "; ", paste(nonoverlaping_samples, collapse = ", "), "\n")
-    cat(".. Subsetting to a commont set\n")
+    cat(".. Subsetting to a common sample set\n")
 
     samples_in_common <- intersect(unique(df$SampleID), unique(df_meta$SampleID))
     if(length(samples_in_common) == 0){ stop("ERROR: no samples in common!\n") }

--- a/bin/network_builder.R
+++ b/bin/network_builder.R
@@ -35,7 +35,7 @@ option_list <- list(
     make_option(c("--replace_missing"),
         type = "logical", default = FALSE, 
         help = "Replace missing metadata"
-    ), 
+    )
 )
 
 # Parse the command line arguments
@@ -52,14 +52,15 @@ replace_missing <- opt$replace_missing
 df_meta <- read_excel(metadata_file)
 
 # Split metadata columns
+if(selected_meta_columns %in% "NA"){ selected_meta_columns <- NA }
 if(is.na(selected_meta_columns)){
-    selected_meta_columns <- colnames(metadata_file)[ ! colnames(metadata_file) %in% "SampleID" ]
+    selected_meta_columns <- colnames(df_meta)[ ! colnames(df_meta) %in% "SampleID" ]
 } else {
     selected_meta_columns <- strsplit(c, split = ",")[[1]]
 }
 
 # Subset metadata
-df_meta  %>%
+df_meta <- df_meta  %>%
     select("SampleID", all_of(selected_meta_columns))
 
 df_meta <- as.data.frame(df_meta)
@@ -74,9 +75,9 @@ if(replace_missing == FALSE){
     # df_meta <- pca_impute(...)
 }
 
+# Metadata variables that will be used for ordination
 final_meta_columns <- colnames(df_meta)
 final_meta_columns <- final_meta_columns[ ! final_meta_columns %in% "SampleID" ]
-
 
 # Load gene abundances, Reads and removes unused columns
 df <- read.csv(input_file) %>%


### PR DESCRIPTION
This PR adds a couple of fixes to the `network_builder` script:
 - handling of categorical variables in capscale
 - removal of samples not present in gene abundance table / sample metadata
 - adds parameter for selecting columns used in capscale
 - verbose messages